### PR TITLE
refactor(login): Replace iframe modal with Electron BrowserWindow

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,4 +1,3 @@
-// esbuild.config.mjs
 import builtins from "builtin-modules";
 import esbuild from "esbuild";
 import process from "process";
@@ -45,8 +44,6 @@ const buildOptions = {
 		"@lezer/common",
 		"@lezer/highlight",
 		"@lezer/lr",
-		"puppeteer-core", // Add puppeteer-core
-		"@puppeteer/browsers", // Add @puppeteer/browsers
 		...builtins,
 	],
 	format: "cjs",

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,48 @@
+# Active Context: Obsidian Kindle Highlights Sync (2025-03-29)
+
+## 1. Current Focus
+
+The immediate focus is on **implementing the Amazon Kindle Cloud Reader authentication mechanism** within the Obsidian plugin. This involves:
+
+*   Creating and refining the `AmazonLoginModal`.
+*   Embedding the Amazon login page securely within the modal.
+*   Detecting successful login by monitoring URL redirection within the embedded view.
+*   Establishing and potentially managing the user's Amazon session (cookies) for subsequent API calls or data scraping.
+*   Implementing the corresponding logout functionality (`AmazonLogoutModal` and session clearing).
+
+## 2. Recent Changes
+
+*   Established the core Memory Bank documents:
+    *   `projectbrief.md`
+    *   `productContext.md`
+    *   `techContext.md`
+    *   `systemPatterns.md`
+*   Clarified project goals, user experience priorities (simplicity), technical stack, and basic system architecture.
+
+## 3. Next Steps (High-Level Plan for Login Feature)
+
+1.  **Develop `AmazonLoginModal`:**
+    *   Create the basic modal structure using Obsidian API (`Modal`).
+    *   Embed an `iframe` within the modal's content area.
+    *   Load the appropriate Amazon login URL based on the user's selected region (from settings).
+2.  **Implement Login Detection:**
+    *   Add event listeners to the `iframe` to monitor `load` or navigation events.
+    *   Check the URL of the loaded page within the `iframe`.
+    *   If the URL matches the expected Kindle Cloud Reader URL for the region, consider the login successful.
+3.  **Handle Session:**
+    *   Determine how the session (cookies) established within the `iframe` context can be leveraged for subsequent data fetching by `KindleApiService`. (This might involve Obsidian's `requestUrl` capabilities or potentially interacting with the `iframe`'s content window if security policies allow).
+    *   Communicate login success/status back to the main plugin/service.
+4.  **Develop Logout Functionality:**
+    *   Create `AmazonLogoutModal` (potentially just a confirmation).
+    *   Implement logic to clear relevant cookies or session data. This is complex due to the `iframe` context and browser security. Research needed on effective methods within Obsidian's environment (e.g., navigating the iframe to a logout URL, attempting to clear cookies via specific APIs if available).
+5.  **Integrate with `KindleApiService`:** Ensure the service can check the login status and utilize the established session.
+6.  **Refine Settings:** Add settings for Amazon region selection if not already present.
+7.  **Testing:** Thoroughly test login/logout across different regions and scenarios (e.g., incorrect password, 2FA).
+
+## 4. Active Decisions & Considerations
+
+*   **Session Management:** How exactly will the session established in the `iframe` be accessed and used by the plugin's background processes/services? Are there security limitations within Obsidian/Electron regarding cross-context cookie access? Will `requestUrl` automatically use these cookies if the requests target the same domain? *Further investigation required.*
+*   **Logout Mechanism:** What is the most reliable way to clear the Amazon session cookies from within the Obsidian plugin context, given they were likely set within an `iframe`? *Further investigation required.*
+*   **WebView Component:** The initial request mentioned "WebView (または同等のコンポーネント)". Obsidian Modals typically use standard HTML DOM. We will use an `iframe` as the standard way to embed external web content within this structure.
+*   **Error Handling:** Define specific error handling for login failures (wrong credentials, network issues, Amazon changes login flow).
+*   **Region Handling:** Ensure login URLs and Cloud Reader redirect URLs are correctly mapped for different Amazon regions (.com, .co.jp, .de, .co.uk, etc.).

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,35 @@
+# Product Context: Obsidian Kindle Highlights Sync
+
+## 1. Why This Project Exists
+
+Reading on Kindle is convenient, but integrating the generated highlights and notes into a personal knowledge base like Obsidian often involves friction. Users desire a seamless way to bring their reading insights into their Obsidian vault without manual steps, allowing them to easily connect ideas and build upon their knowledge.
+
+## 2. Problems Solved
+
+*   **Manual Export/Import:** Eliminates the need for users to manually export highlights from Kindle (e.g., via email, website copy-paste) and import them into Obsidian.
+*   **Data Silos:** Bridges the gap between the Kindle reading ecosystem and the Obsidian knowledge management environment.
+*   **Workflow Interruption:** Reduces context switching and keeps users within their Obsidian workflow when they want to access their Kindle annotations.
+
+## 3. How It Should Work (User Workflow)
+
+1.  **Installation:** User installs the plugin from the Obsidian community plugins browser.
+2.  **Initial Setup (Authentication):**
+    *   User triggers the sync action for the first time (via ribbon icon or command palette).
+    *   An Amazon login modal appears.
+    *   User logs into their Amazon account securely within the modal.
+    *   Successful login is detected, and the modal closes. The session is established.
+3.  **Synchronization:**
+    *   User triggers the sync action (ribbon icon or command palette).
+    *   The plugin communicates with the Kindle Cloud Reader in the background using the established session.
+    *   New or updated highlights and notes are fetched.
+    *   Corresponding notes are created or updated within Obsidian according to basic default settings.
+    *   A notification confirms sync completion (or reports errors).
+4.  **Configuration (Optional):** Users can access plugin settings to potentially adjust the target folder, note format (using a simple default template initially), and Amazon region if needed.
+5.  **Logout:** User can explicitly log out via a command or settings option, clearing the session data.
+
+## 4. User Experience Goals
+
+*   **Simplicity:** The primary goal is a "one-click" sync experience after the initial setup. Authentication should be straightforward and secure.
+*   **Reliability:** Synchronization should consistently fetch all available highlights and handle potential errors gracefully (e.g., network issues, login expiry).
+*   **Unobtrusiveness:** Background processing should minimize disruption to the user's ongoing work in Obsidian. Clear notifications should provide status updates without being intrusive.
+*   **Discoverability:** Key actions like initiating sync and accessing settings should be easily discoverable through standard Obsidian UI elements (ribbon, command palette, settings tab).

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,45 @@
+# Progress: Obsidian Kindle Highlights Sync (2025-03-29)
+
+## 1. What Works
+
+*   **Basic Plugin Structure:** The fundamental Obsidian plugin structure (`main.ts`, `manifest.json`, settings tab via `settings.ts`) is in place.
+*   **Build Process:** The project can be built using TypeScript and esbuild.
+*   **Core Service Stubs:** Service files for API interaction (`kindle-api.ts`), parsing (`highlight-parser.ts`), rendering (`template-renderer.ts`), and metadata (`metadata-service.ts`) exist, outlining the intended separation of concerns.
+*   **Data Models:** Basic data models for `Book` and `Highlight` (`models/`) are defined.
+*   **Memory Bank:** Core documentation files (`projectbrief.md`, `productContext.md`, `techContext.md`, `systemPatterns.md`, `activeContext.md`) have been established.
+
+## 2. What's Left to Build (Focus: Login Feature)
+
+*   **Amazon Login Modal (`AmazonLoginModal.ts`):**
+    *   Implement `iframe` embedding of the Amazon login page.
+    *   Implement dynamic loading of region-specific login URLs.
+    *   Implement robust detection of successful login via URL redirection monitoring.
+    *   Implement communication of login status (success/failure) back to the main plugin/service.
+*   **Session Management (`KindleApiService` / `AmazonLoginModal`):**
+    *   Determine and implement the mechanism for leveraging the established session (cookies) for subsequent actions.
+    *   Implement secure handling/storage if necessary (though reliance on implicit session is the current plan).
+*   **Amazon Logout Modal & Logic (New):**
+    *   Create the `AmazonLogoutModal`.
+    *   Implement the logic to effectively clear the Amazon session/cookies within the Obsidian environment.
+*   **Integration (`KindleApiService`, `main.ts`):**
+    *   Integrate the login status check into the sync workflow.
+    *   Ensure `KindleApiService` uses the established session for data fetching.
+*   **Data Fetching (`KindleApiService`):**
+    *   Implement the actual logic to fetch books and highlights from Kindle Cloud Reader using the authenticated session (likely involving scraping or interacting with the Cloud Reader's internal APIs if accessible).
+*   **Parsing & Rendering Logic:**
+    *   Flesh out the implementation details in `HighlightParser` and `TemplateRenderer` to process the fetched data and create Obsidian notes.
+*   **Settings Refinement:** Add UI elements for Amazon region selection and potentially other login-related settings.
+*   **Error Handling:** Implement comprehensive error handling for login, logout, and data fetching processes.
+*   **Testing:** Conduct thorough testing across different scenarios and Amazon regions.
+
+## 3. Current Status
+
+*   **Planning & Setup:** The project is in the initial implementation phase for the core Cloud Reader authentication feature. Foundational documentation and project structure are set up.
+*   **Blocked:** The primary functionality (syncing highlights) is blocked until the authentication mechanism is successfully implemented.
+
+## 4. Known Issues & Blockers
+
+*   **Authentication Implementation:** The core task of implementing the `iframe`-based login, session handling, and logout is the main blocker. Technical challenges related to cross-context scripting, cookie management, and the brittleness of relying on Amazon's web UI structure are anticipated.
+*   **Session Persistence/Usage:** Uncertainty remains about the best way to reliably use the `iframe`-established session for background API calls/scraping within Obsidian's limitations.
+*   **Logout Reliability:** Clearing cookies set within an `iframe` from the parent context can be technically challenging and requires investigation.
+*   **Scraping Brittleness:** The data fetching process, likely relying on scraping the Cloud Reader HTML, will be prone to breaking if Amazon updates its website.

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -1,0 +1,36 @@
+# Project Brief: Obsidian Kindle Highlights Sync
+
+## 1. Project Goal
+
+The primary goal of this project is to enable users to easily synchronize their Kindle highlights and notes directly into their Obsidian vault.
+
+## 2. Problem Statement
+
+Kindle users often highlight passages and make notes while reading. Accessing and integrating these annotations into personal knowledge management systems like Obsidian can be cumbersome, often requiring manual export/import processes or relying on less direct methods. This plugin aims to streamline this workflow.
+
+## 3. Core Requirements
+
+*   Fetch highlights and notes from a user's Kindle account.
+*   Format and import these annotations into Obsidian notes.
+*   Provide a user-friendly interface within Obsidian for managing the synchronization process.
+*   Support different Amazon regional domains (e.g., .com, .co.jp, .co.uk).
+*   Allow users to customize the format and organization of imported notes.
+
+## 4. Scope
+
+*   **In Scope:**
+    *   Authentication with Amazon Kindle Cloud Reader.
+    *   Fetching book metadata, highlights, and notes.
+    *   Creating/updating Obsidian notes based on fetched data.
+    *   Configuration options for sync behavior and note formatting.
+    *   Handling different Amazon regions.
+*   **Out of Scope (Initially):**
+    *   Syncing annotations *from* Obsidian *to* Kindle.
+    *   Advanced conflict resolution beyond simple overwrites or updates.
+    *   Support for non-Amazon e-reader platforms.
+
+## 5. Success Metrics
+
+*   Users can successfully authenticate and sync their Kindle highlights.
+*   The synchronization process is reliable and efficient.
+*   User feedback indicates a significant improvement in their workflow for integrating Kindle notes into Obsidian.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -1,0 +1,79 @@
+# System Patterns: Obsidian Kindle Highlights Sync
+
+## 1. Overall Architecture
+
+The plugin follows a relatively simple, centralized architecture rather than adhering strictly to a formal design pattern like MVC or MVVM. The core `KindleHighlightsPlugin` class (`src/main.ts`) acts as the central orchestrator.
+
+## 2. Key Components & Interactions
+
+```mermaid
+graph TD
+    User --> ObsidianUI[Obsidian UI (Ribbon, Command Palette, Settings)]
+    ObsidianUI --> MainPlugin(KindleHighlightsPlugin / main.ts)
+
+    subgraph Plugin Core
+        MainPlugin --> SettingsTab(SettingsTab / settings.ts)
+        MainPlugin -->|Triggers Sync| SyncProcess{Sync Logic}
+        MainPlugin -->|Needs Login| LoginModal(AmazonLoginModal / modals/AmazonLoginModal.ts)
+        MainPlugin -->|Needs Logout| LogoutModal(AmazonLogoutModal / modals/AmazonLogoutModal.ts) -- Planned
+        MainPlugin -->|Displays Status| NoticeAPI[Obsidian Notice API]
+
+        SyncProcess --> KindleAPI(KindleApiService / services/kindle-api.ts)
+        SyncProcess --> Parser(HighlightParser / services/highlight-parser.ts) -- Planned/Implicit
+        SyncProcess --> Renderer(TemplateRenderer / services/template-renderer.ts)
+        SyncProcess --> MetadataService(MetadataService / services/metadata-service.ts) -- Planned/Implicit
+        SyncProcess --> VaultAPI[Obsidian Vault API]
+
+        KindleAPI -->|Fetches Data| AmazonCloudReader[Amazon Cloud Reader (via embedded view/requests)]
+        Renderer --> VaultAPI
+    end
+
+    SettingsTab --> MainPlugin -- Saves Settings
+
+    LoginModal -->|Handles Login| AmazonCloudReader
+    LoginModal -->|On Success/Failure| MainPlugin
+
+    LogoutModal -->|Handles Logout| MainPlugin -- Planned
+```
+
+*   **`KindleHighlightsPlugin` (`src/main.ts`):**
+    *   The main entry point and central controller.
+    *   Initializes the plugin, loads settings, registers commands, adds ribbon icons, and sets up the settings tab.
+    *   Orchestrates the synchronization process, deciding when to show the login modal or proceed with fetching data.
+    *   Instantiates and interacts with various `Service` classes.
+*   **`SettingsTab` (`src/settings.ts`):**
+    *   Provides the user interface for configuring plugin settings (e.g., Amazon region, note template, output folder).
+    *   Saves settings using Obsidian's data persistence mechanisms.
+*   **`AmazonLoginModal` (`src/modals/AmazonLoginModal.ts`):**
+    *   Displays the Amazon login page within an embedded view (likely an `iframe`).
+    *   Monitors navigation within the embedded view to detect successful login (redirection to Kindle Cloud Reader URL).
+    *   Communicates login success or failure back to the `MainPlugin`.
+    *   Handles the storage or management of the session/cookies upon successful login (details TBD).
+*   **`AmazonLogoutModal` (Planned):**
+    *   Provides a confirmation or interface for logging out.
+    *   Triggers the clearing of session data (cookies).
+*   **Services (`src/services/`):**
+    *   **`KindleApiService` (`kindle-api.ts`):** Responsible for all communication related to Amazon, including managing the login state (session/cookies) and fetching data (books, highlights) from the Cloud Reader. This will likely involve interacting with the embedded view's content or making authenticated requests.
+    *   **`HighlightParser` (`highlight-parser.ts`):** Parses the raw data fetched from Kindle Cloud Reader into structured `Book` and `Highlight` models. (Functionality might be partially within `KindleApiService` initially).
+    *   **`TemplateRenderer` (`template-renderer.ts`):** Takes the structured data and user-defined templates to generate the Markdown content for Obsidian notes.
+    *   **`MetadataService` (`metadata-service.ts`):** Potentially handles fetching or enriching book metadata (e.g., cover images, author details) if not directly available from the primary highlight data source.
+*   **Models (`src/models/`):** Defines the data structures (`Book`, `Highlight`) used throughout the plugin.
+
+## 3. Design Decisions & Patterns
+
+*   **Centralized Control:** Logic flows primarily from the `MainPlugin` class.
+*   **Service Layer:** Functionality is grouped into services (API, Parsing, Rendering) to promote separation of concerns, although the boundaries might evolve.
+*   **Modal-based Authentication:** User interaction for login/logout is handled via dedicated Modals.
+*   **Configuration via Settings:** Plugin behavior is customized through the standard Obsidian settings tab.
+*   **Asynchronous Operations:** Interactions with APIs (Obsidian, Amazon) and file system operations are asynchronous, likely using `async/await`. Error handling for these operations is crucial.
+
+## 4. State Management
+
+*   Plugin settings are managed via `loadData()` and `saveData()` provided by the Obsidian API.
+*   Authentication state (e.g., session cookies, login status) needs to be managed, likely within the `KindleApiService` or potentially stored securely using Obsidian's mechanisms if appropriate, although the current plan involves relying on the implicit session maintained by the embedded view context.
+
+## 5. Error Handling
+
+*   Errors during API calls, parsing, or file writing should be caught gracefully.
+*   User-facing errors should be reported via Obsidian's `Notice` API.
+*   Login failures need specific handling within the `AmazonLoginModal`.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -1,0 +1,54 @@
+# Tech Context: Obsidian Kindle Highlights Sync
+
+## 1. Core Technologies
+
+*   **Language:** TypeScript - Provides static typing for improved code quality and maintainability.
+*   **Runtime:** Node.js - Used for dependency management (npm) and build processes.
+*   **Framework:** Obsidian Plugin API - Leverages the official API provided by Obsidian for extending its functionality.
+
+## 2. Build & Development Tools
+
+*   **Bundler:** esbuild - Used for fast TypeScript compilation and bundling of the plugin code into `main.js`. Configured via `esbuild.config.mjs`.
+*   **Package Manager:** npm - Manages project dependencies listed in `package.json` and `package-lock.json`.
+*   **Linter:** ESLint - Enforces code style and identifies potential errors. Configured via `.eslintrc`.
+*   **Configuration:**
+    *   `tsconfig.json`: Configures TypeScript compiler options.
+    *   `.editorconfig`: Helps maintain consistent coding styles across different editors.
+    *   `.gitignore`: Specifies intentionally untracked files for Git.
+
+## 3. Key Obsidian API Components Used (Inferred)
+
+Based on the file structure (`src/main.ts`, `src/settings.ts`, `src/modals/AmazonLoginModal.ts`) and common plugin patterns, the following Obsidian API components are likely used or planned:
+
+*   `Plugin`: The base class for the Obsidian plugin (`main.ts`).
+*   `PluginSettingTab`, `Setting`: For creating the plugin's settings interface (`settings.ts`).
+*   `Modal`: Used for displaying modal windows, specifically the `AmazonLoginModal` for the login process. This modal will likely embed the Amazon login page using an `<iframe>`.
+*   `Notice`: For displaying brief notifications to the user (e.g., sync success/failure).
+*   `requestUrl`: Potentially used for making HTTP requests to fetch Kindle data after authentication (`services/kindle-api.ts`), although the primary data fetching might involve interacting with the content loaded after login within the Cloud Reader context.
+*   Obsidian Commands API: To register commands for triggering sync (e.g., via Command Palette).
+*   Ribbon Icon API: To add a ribbon icon for triggering sync.
+
+## 4. Project Structure
+
+*   `src/`: Contains all source code.
+    *   `main.ts`: Plugin entry point.
+    *   `settings.ts`: Handles plugin settings.
+    *   `modals/`: Contains modal component definitions.
+    *   `models/`: Defines data structures (e.g., `Book`, `Highlight`).
+    *   `services/`: Encapsulates specific functionalities (API interaction, parsing, rendering).
+    *   `templates/`: Contains templates for generating Obsidian notes.
+*   `manifest.json`: Plugin metadata required by Obsidian.
+*   `versions.json`, `version-bump.mjs`: Likely used for managing plugin versioning.
+
+## 5. Dependencies
+
+*   Primary dependency is the `obsidian` API module.
+*   Development dependencies include `typescript`, `esbuild`, `@types/node`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint`.
+*   No major external runtime libraries are apparent in the current structure, but scraping libraries (like Cheerio) might be considered later for parsing Cloud Reader content if direct API calls are not feasible.
+
+## 6. Technical Constraints & Considerations
+
+*   **Obsidian API Limitations:** Plugin execution is sandboxed within Obsidian's environment. Direct access to certain system resources or complex browser APIs (like full Puppeteer control) might be restricted.
+*   **Authentication:** Relies on embedding the Amazon login page within a modal/iframe and capturing cookies/session information upon successful login redirect. This approach is sensitive to changes in Amazon's login flow.
+*   **Scraping:** Fetching highlights post-login will likely involve parsing the HTML structure of the Kindle Cloud Reader. This is inherently brittle and may break if Amazon updates the Cloud Reader's UI.
+*   **Security:** As noted in the initial request, the established Amazon session (cookies) might be accessible within the Obsidian environment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@rollup/plugin-commonjs": "^28.0.3",
 				"@rollup/plugin-node-resolve": "^16.0.1",
 				"@rollup/plugin-typescript": "^12.1.2",
+				"@types/electron": "^1.4.38",
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
@@ -1067,6 +1068,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/tern": "*"
+			}
+		},
+		"node_modules/@types/electron": {
+			"version": "1.4.38",
+			"resolved": "https://registry.npmjs.org/@types/electron/-/electron-1.4.38.tgz",
+			"integrity": "sha512-Cu6laqBamT6VSPi0LLlF9vE9Os8EbTaI/5eJSsd7CPoLUG3Znjh04u9TxMhQYPF1wGFM14Z8TFQ2914JZ+rGLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@rollup/plugin-commonjs": "^28.0.3",
 		"@rollup/plugin-node-resolve": "^16.0.1",
 		"@rollup/plugin-typescript": "^12.1.2",
+		"@types/electron": "^1.4.38",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",

--- a/src/modals/AmazonLoginModal.ts
+++ b/src/modals/AmazonLoginModal.ts
@@ -1,113 +1,173 @@
-import { App, Modal, Notice, Setting } from "obsidian";
+// Removed import type - rely on @types/electron and require
+import { Notice } from "obsidian";
+import { getRegionUrls } from "../services/kindle-api"; // Import helper
 
-// Define the expected structure for successful login result
-export interface AmazonSession {
-	cookies: string; // Or a more structured cookie representation
-	// Add other relevant session details if needed
-}
+// Attempt to import Electron remote module - this might vary depending on Obsidian/Electron version
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const electron = require("electron");
+const remote = electron?.remote || electron?.contextBridge?.electron?.remote; // Handle potential variations
+const BrowserWindow = remote?.BrowserWindow; // Use original name
 
-export class AmazonLoginModal extends Modal {
-	private sessionPromise: Promise<AmazonSession | null>;
-	private resolvePromise: (session: AmazonSession | null) => void;
-	// Add state variables for email, password, MFA code if needed
+export class AmazonLoginModal {
+	private loginPromise: Promise<boolean>; // Resolves true on success, false on cancel/failure
+	private resolvePromise!: (success: boolean) => void; // Definite assignment assertion
+	private modal: Electron.BrowserWindow | null = null; // Use Electron namespace type
+	private readonly loginUrl: string | null;
+	private readonly cloudReaderUrl: string | null;
+	private readonly notebookUrl: string | null; // Added notebookUrl for potential use
 
-	constructor(app: App, private region: string) {
-		super(app);
-		// Initialize state variables
-		this.sessionPromise = new Promise((resolve) => {
+	constructor(private region: string) {
+		// Removed App dependency as we are not extending Modal
+
+		const regionUrls = getRegionUrls(this.region);
+		if (!regionUrls) {
+			// Log error, but let doLogin handle user notification
+			console.error(
+				`Error: Invalid Amazon region configured: ${this.region}`
+			);
+			this.loginUrl = null;
+			this.cloudReaderUrl = null;
+			this.notebookUrl = null;
+		} else {
+			this.loginUrl = regionUrls.loginUrl;
+			this.cloudReaderUrl = regionUrls.cloudReaderUrl;
+			this.notebookUrl = regionUrls.notebookUrl; // Store notebook URL
+		}
+
+		// Initialize the promise
+		this.loginPromise = new Promise((resolve) => {
 			this.resolvePromise = resolve;
 		});
-	}
 
-	/**
-	 * Opens the modal and returns a promise that resolves with session details
-	 * upon successful login, or null if cancelled/failed.
-	 */
-	public async doLogin(): Promise<AmazonSession | null> {
-		this.open();
-		return this.sessionPromise;
-	}
-
-	onOpen() {
-		const { contentEl } = this;
-		contentEl.empty();
-		contentEl.createEl("h2", { text: `Amazon (${this.region}) Login` });
-
-		// TODO: Build the login form (email, password, potentially MFA input)
-		// Example:
-		// new Setting(contentEl)
-		//   .setName("Email")
-		//   .addText(text => text.onChange(value => this.email = value));
-		// new Setting(contentEl)
-		//   .setName("Password")
-		//   .addText(text => text.setInputType("password").onChange(value => this.password = value));
-
-		new Setting(contentEl).addButton((button) =>
-			button
-				.setButtonText("Login")
-				.setCta()
-				.onClick(() => {
-					this.handleLoginSubmit();
-				})
-		);
-
-		// Add Cancel button
-		new Setting(contentEl).addButton((button) =>
-			button.setButtonText("Cancel").onClick(() => {
-				this.resolvePromise(null);
-				this.close();
-			})
-		);
-	}
-
-	private async handleLoginSubmit() {
-		// TODO: Implement the actual login logic using requestUrl
-		// 1. Send initial request with email/password
-		// 2. Handle response:
-		//    - Check for success (capture cookies) -> resolvePromise(session)
-		//    - Check for MFA prompt -> Show MFA input field
-		//    - Check for CAPTCHA -> Notify user (hard to solve programmatically)
-		//    - Check for other errors -> Show error Notice
-		// 3. If MFA needed, send second request with MFA code
-		// 4. Handle MFA response (capture cookies) -> resolvePromise(session)
-
-		try {
-			new Notice("Login logic not yet implemented.");
-			// Placeholder: Simulate failure/cancellation for now
-			this.resolvePromise(null);
-			this.close();
-
-			/* Example structure for requestUrl usage:
-            const response = await requestUrl({
-                url: `https://www.amazon.${this.region}/ap/signin`, // Adjust URL
-                method: 'POST',
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: new URLSearchParams({ email: this.email, password: this.password }).toString(),
-                throw: false // Handle errors manually
-            });
-
-            if (response.status === 200 && response.headers['set-cookie']) {
-                // Extract cookies, potentially navigate redirects
-                const cookies = response.headers['set-cookie']; // Needs proper parsing
-                const session: AmazonSession = { cookies: cookies };
-                this.resolvePromise(session);
-                this.close();
-            } else {
-                // Handle MFA, CAPTCHA, errors
-                new Notice(`Login failed: Status ${response.status}`);
-                // Potentially show MFA input here
-            }
-            */
-		} catch (error) {
-			console.error("Amazon login error:", error);
-			new Notice(`Login error: ${error.message}`);
-			this.resolvePromise(null);
-			this.close();
+		// Check if BrowserWindow is available
+		if (!BrowserWindow) {
+			// Use the correct variable name
+			console.error(
+				"AmazonLoginModal: Electron BrowserWindow is not available. Cannot create login window.",
+				this.resolvePromise(false)
+			);
 		}
 	}
 
-	onClose() {
-		const { contentEl } = this;
-		contentEl.empty();
+	/**
+	 * Opens a new browser window for Amazon login and returns a promise
+	 * that resolves with true upon successful login, or false if cancelled/failed.
+	 */
+	public async doLogin(): Promise<boolean> {
+		// Ensure URLs are valid and BrowserWindow is available
+		if (
+			!this.loginUrl ||
+			!this.cloudReaderUrl ||
+			!this.notebookUrl ||
+			!BrowserWindow
+		) {
+			new Notice(
+				"Error: Cannot initiate login. Invalid Amazon region configuration or Electron components unavailable."
+			);
+			this.resolvePromise(false); // Resolve immediately if prerequisites fail
+			return this.loginPromise; // Return the already resolved promise
+		}
+
+		// Create the BrowserWindow instance
+		this.modal = new BrowserWindow({
+			parent: remote?.getCurrentWindow(), // Optional: makes it a modal to the main Obsidian window
+			width: 500, // Adjusted size
+			height: 750,
+			show: false, // Don't show until ready
+			webPreferences: {
+				nodeIntegration: false, // Important for security
+				// contextIsolation: true, // Removed - Property does not exist on type 'WebPreferences' in installed types
+				// partition: `persist:amazon-login-${this.region}` // Optional: Isolate session/cookies per region
+			},
+		});
+
+		// --- Event Listeners ---
+
+		// Show window when it's ready
+		if (this.modal) {
+			// Add null check before attaching listener
+			this.modal.on("ready-to-show", () => {
+				// Change once to on
+				if (this.modal) {
+					// Keep inner null check for safety within callback
+					this.modal.setTitle(
+						`Amazon (${this.region}) Login - Kindle Highlights Sync`
+					);
+					this.modal.show();
+					console.log("AmazonLoginModal: Login window shown.");
+				}
+			});
+
+			// Detect successful login navigation
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			this.modal.webContents.on("did-navigate", (_event, url: string) => {
+				// Removed : Event type annotation
+				// Added types for _event and url
+				console.log("AmazonLoginModal: Navigated to URL:", url); // Log navigation
+				// Check if navigated to the Cloud Reader URL (indicates success)
+				if (
+					this.cloudReaderUrl &&
+					url.startsWith(this.cloudReaderUrl)
+				) {
+					console.log(
+						"AmazonLoginModal: Success detected (Cloud Reader URL)."
+					);
+					new Notice("Amazon login successful!");
+					this.resolvePromise(true);
+					this.closeWindow(); // Close the window safely
+				}
+				// Optional: Could also check for notebookUrl if loginUrl redirects there first
+				// else if (this.notebookUrl && url.startsWith(this.notebookUrl)) {
+				//     console.log("AmazonLoginModal: Success detected (Notebook URL).");
+				//     new Notice("Amazon login successful!");
+				//     this.resolvePromise(true);
+				//     this.closeWindow();
+				// }
+			});
+
+			// Handle window being closed by the user or other means
+			this.modal.on("closed", () => {
+				console.log("AmazonLoginModal: Login window closed.");
+				// Only resolve as false if the promise hasn't already been resolved (e.g., by successful navigation)
+				// This prevents overwriting a successful login if 'closed' fires slightly after 'did-navigate' success
+				this.loginPromise.then((alreadyResolved) => {
+					if (!alreadyResolved) {
+						this.resolvePromise(false);
+					}
+				});
+				this.modal = null; // Clean up reference
+			});
+		} // <-- Add missing closing brace for the `if (this.modal)` block started on line 86
+
+		// --- Load Login URL ---
+		// Also add null check here before calling loadURL
+		if (this.modal) {
+			try {
+				console.log(`AmazonLoginModal: Loading URL: ${this.loginUrl}`);
+				// Load the specific login URL which should redirect to Cloud Reader on success
+				await this.modal.loadURL(this.loginUrl);
+			} catch (error) {
+				console.error("AmazonLoginModal: Error loading URL:", error);
+				// The example code swallowed errors here, assuming successful login interrupts loading.
+				// However, a genuine error could occur. We might still rely on did-navigate or closed events.
+				// If the window doesn't open or load, the 'closed' event should eventually resolve(false).
+			}
+		} // <-- Add missing closing brace for the `if (this.modal)` block started on line 142
+
+		return this.loginPromise;
 	}
+
+	// Helper to safely close the window
+	private closeWindow() {
+		if (this.modal && !this.modal.isDestroyed()) {
+			try {
+				this.modal.close();
+			} catch (e) {
+				console.error("AmazonLoginModal: Error closing window:", e);
+			}
+		}
+		this.modal = null;
+	}
+
+	// No longer need onOpen or onClose as we're not using Obsidian's Modal
 }

--- a/src/modals/AmazonLogoutModal.ts
+++ b/src/modals/AmazonLogoutModal.ts
@@ -1,0 +1,61 @@
+import { App, Modal, Notice } from "obsidian";
+import { KindleApiService } from "../services/kindle-api";
+
+export class AmazonLogoutModal extends Modal {
+	constructor(
+		app: App,
+		private kindleApiService: KindleApiService,
+		private region: string // Add region parameter
+	) {
+		super(app);
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass("amazon-logout-modal");
+
+		contentEl.createEl("h2", { text: "Amazon Logout Confirmation" });
+		contentEl.createEl("p", {
+			text: "Are you sure you want to log out from your Amazon Kindle session within Obsidian?",
+		});
+		contentEl.createEl("p", {
+			text: "Note: This attempts to clear the session. You may need to log in again next time.",
+			cls: "mod-warning",
+		});
+
+		const buttonContainer = contentEl.createDiv({
+			cls: "modal-button-container",
+		});
+
+		// Logout Button
+		const logoutButton = buttonContainer.createEl("button", {
+			text: "Logout",
+			cls: "mod-cta", // Call to action style
+		});
+		logoutButton.onclick = async () => {
+			new Notice("Logging out...");
+			this.close(); // Close modal first
+			try {
+				await this.kindleApiService.logout(this.region); // Pass region to logout method
+				// Notice is handled within the service logout method now
+			} catch (error) {
+				console.error("Error during logout:", error);
+				new Notice(`Logout failed: ${error.message}`);
+			}
+		};
+
+		// Cancel Button
+		const cancelButton = buttonContainer.createEl("button", {
+			text: "Cancel",
+		});
+		cancelButton.onclick = () => {
+			this.close();
+		};
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}

--- a/src/services/kindle-api.ts
+++ b/src/services/kindle-api.ts
@@ -1,177 +1,362 @@
 import * as cheerio from "cheerio";
-import { Notice, requestUrl } from "obsidian";
-import type { AmazonSession } from "../modals/AmazonLoginModal"; // Assuming session structure
+import { App, Notice, requestUrl } from "obsidian"; // Added App
+import { AmazonLoginModal } from "../modals/AmazonLoginModal"; // Import the modal
 import { Book, Highlight } from "../models";
 
-// --- Constants ---
-// Standard User Agent to mimic a browser
+// --- Region URL Definitions --- (Keep outside class for now)
+
+interface AmazonRegionUrls {
+	loginUrl: string;
+	cloudReaderUrl: string;
+	notebookUrl: string;
+	logoutUrl: string; // Added logout URL
+}
+
+const REGION_URLS: Record<string, AmazonRegionUrls> = {
+	com: {
+		loginUrl:
+			"https://www.amazon.com/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.com%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_us&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.com/",
+		notebookUrl: "https://read.amazon.com/notebook",
+		logoutUrl: "https://www.amazon.com/gp/flex/sign-out.html", // Standard logout URL
+	},
+	"co.jp": {
+		loginUrl:
+			"https://www.amazon.co.jp/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.co.jp%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_jp&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.co.jp/",
+		notebookUrl: "https://read.amazon.co.jp/notebook",
+		logoutUrl: "https://www.amazon.co.jp/gp/flex/sign-out.html",
+	},
+	"co.uk": {
+		loginUrl:
+			"https://www.amazon.co.uk/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.co.uk%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_uk&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.co.uk/",
+		notebookUrl: "https://read.amazon.co.uk/notebook",
+		logoutUrl: "https://www.amazon.co.uk/gp/flex/sign-out.html",
+	},
+	de: {
+		loginUrl:
+			"https://www.amazon.de/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.de%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_de&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.de/",
+		notebookUrl: "https://read.amazon.de/notebook",
+		logoutUrl: "https://www.amazon.de/gp/flex/sign-out.html",
+	},
+	fr: {
+		loginUrl:
+			"https://www.amazon.fr/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.fr%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_fr&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.fr/",
+		notebookUrl: "https://read.amazon.fr/notebook",
+		logoutUrl: "https://www.amazon.fr/gp/flex/sign-out.html",
+	},
+	es: {
+		loginUrl:
+			"https://www.amazon.es/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.es%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_es&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.es/",
+		notebookUrl: "https://read.amazon.es/notebook",
+		logoutUrl: "https://www.amazon.es/gp/flex/sign-out.html",
+	},
+	it: {
+		loginUrl:
+			"https://www.amazon.it/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.it%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_it&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.it/",
+		notebookUrl: "https://read.amazon.it/notebook",
+		logoutUrl: "https://www.amazon.it/gp/flex/sign-out.html",
+	},
+	ca: {
+		loginUrl:
+			"https://www.amazon.ca/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.ca%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_ca&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.ca/",
+		notebookUrl: "https://read.amazon.ca/notebook",
+		logoutUrl: "https://www.amazon.ca/gp/flex/sign-out.html",
+	},
+	"com.au": {
+		loginUrl:
+			"https://www.amazon.com.au/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.com.au%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_au&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.com.au/",
+		notebookUrl: "https://read.amazon.com.au/notebook",
+		logoutUrl: "https://www.amazon.com.au/gp/flex/sign-out.html",
+	},
+	"com.br": {
+		loginUrl:
+			"https://www.amazon.com.br/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.com.br%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_br&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.com.br/",
+		notebookUrl: "https://read.amazon.com.br/notebook",
+		logoutUrl: "https://www.amazon.com.br/gp/flex/sign-out.html",
+	},
+	"com.mx": {
+		loginUrl:
+			"https://www.amazon.com.mx/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.com.mx%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_mx&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.com.mx/",
+		notebookUrl: "https://read.amazon.com.mx/notebook",
+		logoutUrl: "https://www.amazon.com.mx/gp/flex/sign-out.html",
+	},
+	in: {
+		loginUrl:
+			"https://www.amazon.in/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fread.amazon.in%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kp_mobile_in&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&",
+		cloudReaderUrl: "https://read.amazon.in/",
+		notebookUrl: "https://read.amazon.in/notebook",
+		logoutUrl: "https://www.amazon.in/gp/flex/sign-out.html",
+	},
+};
+
+export function getRegionUrls(region: string): AmazonRegionUrls | undefined {
+	return REGION_URLS[region];
+}
+
+// --- Constants --- (Keep outside class)
 const USER_AGENT =
 	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36";
-// Base URL for Kindle Cloud Reader Notebook
-const BASE_URL = "https://read.amazon.";
 
-// --- CSS Selectors ---
-// IMPORTANT: These selectors are based on the observed structure of the Kindle Cloud Reader
-// notebook page as of the time of writing. Amazon may change its website structure
-// at any time, which WILL BREAK this scraping logic. Regular maintenance and updates
-// to these selectors will likely be required.
-const BOOK_SELECTOR = ".kp-notebook-library-each-book"; // Selector for each book entry in the sidebar
+// --- CSS Selectors --- (Keep outside class)
+const BOOK_SELECTOR = ".kp-notebook-library-each-book";
 const BOOK_ASIN_ATTR = "data-asin";
 const BOOK_TITLE_SELECTOR = ".kp-notebook-library-book-title";
 const BOOK_AUTHOR_SELECTOR = ".kp-notebook-library-book-author";
-const BOOK_COVER_SELECTOR = "img.kp-notebook-cover-image"; // Check if this selector is correct
-
-// IMPORTANT: Like book selectors, these highlight selectors are fragile and subject to change by Amazon.
+// const BOOK_COVER_SELECTOR = "img.kp-notebook-cover-image"; // Commented out - not currently used
 const HIGHLIGHT_CONTAINER_SELECTOR =
-	".a-row.a-spacing-base.kp-notebook-highlight"; // Container for a single highlight + note
-const HIGHLIGHT_TEXT_SELECTOR = "#highlight"; // ID for the highlight text itself
-const HIGHLIGHT_NOTE_SELECTOR = "#note"; // ID for the user's note on the highlight
-const HIGHLIGHT_LOCATION_SELECTOR = "#annotationHighlightHeader"; // Contains location info (needs parsing)
-const HIGHLIGHT_ASIN_ATTR = "data-asin"; // Assuming the container has the book ASIN
+	".a-row.a-spacing-base.kp-notebook-highlight";
+const HIGHLIGHT_TEXT_SELECTOR = "#highlight";
+const HIGHLIGHT_NOTE_SELECTOR = "#note";
+const HIGHLIGHT_LOCATION_SELECTOR = "#annotationHighlightHeader";
+const HIGHLIGHT_ASIN_ATTR = "data-asin";
 
-/**
- * Scrapes books and highlights from the Kindle Cloud Reader notebook page.
- * Requires a valid AmazonSession with cookies.
- */
-export async function scrapeKindleHighlights(
-	region: string,
-	session: AmazonSession // Changed from credentials to session
-): Promise<{ books: Book[]; highlights: Highlight[] }> {
-	const notebookUrl = `${BASE_URL}${region}/notebook`;
-	console.log(`Attempting to scrape Kindle notebook: ${notebookUrl}`);
+export class KindleApiService {
+	private loggedIn = false; // Type inferred from literal
+	private app: App; // Store App instance
 
-	try {
-		const response = await requestUrl({
-			url: notebookUrl,
-			method: "GET",
-			headers: {
-				"User-Agent": USER_AGENT,
-				Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-				"Accept-Language": "en-US,en;q=0.9",
-				Cookie: session.cookies, // Use cookies from the authenticated session
-				// Add other headers if necessary based on browser inspection
-			},
-			throw: false, // Handle errors manually
-		});
+	constructor(app: App) {
+		this.app = app;
+	}
 
-		console.log(`Scraping response status: ${response.status}`);
+	public isLoggedIn(): boolean {
+		return this.loggedIn;
+	}
 
-		// Check for potential redirect to login page (indicating invalid session)
-		if (response.status >= 300 && response.status < 400) {
-			// Check response headers for location pointing to signin
-			const location = response.headers["location"];
-			if (location && location.includes("/ap/signin")) {
-				throw new Error(
-					"Authentication failed or session expired. Please log in again."
-				);
-			}
+	/**
+	 * Initiates the login process using the AmazonLoginModal.
+	 * @param region The Amazon region code (e.g., 'com', 'co.jp').
+	 * @returns True if login was successful, false otherwise.
+	 */
+	public async login(region: string): Promise<boolean> {
+		console.log("KindleApiService: Initiating login...");
+		const loginModal = new AmazonLoginModal(region); // Removed this.app argument
+		const success = await loginModal.doLogin();
+		if (success) {
+			this.loggedIn = true;
+			console.log("KindleApiService: Login successful.");
+		} else {
+			this.loggedIn = false; // Ensure state is false on cancel/failure
+			console.log("KindleApiService: Login cancelled or failed.");
 		}
+		return success;
+	}
 
-		if (response.status !== 200) {
-			throw new Error(
-				`Failed to fetch Kindle Notebook page. Status: ${response.status}`
+	/**
+	 * Logs the user out by resetting the internal state.
+	 * TODO: Implement actual session clearing (e.g., cookie removal).
+	 */
+	public async logout(region: string): Promise<void> {
+		// Added region parameter
+		console.log("KindleApiService: Logging out...");
+		this.loggedIn = false;
+
+		// Attempt to clear session via hidden iframe (best effort)
+		const regionUrls = getRegionUrls(region);
+		if (regionUrls?.logoutUrl) {
+			console.log(
+				`Attempting logout via iframe navigation to: ${regionUrls.logoutUrl}`
 			);
-		}
+			try {
+				const iframe = document.createElement("iframe");
+				iframe.style.display = "none"; // Keep it hidden
+				iframe.src = regionUrls.logoutUrl;
+				document.body.appendChild(iframe);
 
-		const html = response.text;
-		const $ = cheerio.load(html);
+				// Wait a short period for the navigation to potentially clear cookies
+				await new Promise((resolve) => setTimeout(resolve, 1500)); // Wait 1.5 seconds
 
-		const books: Book[] = [];
-		const highlights: Highlight[] = [];
-
-		// --- Parse Books ---
-		$(BOOK_SELECTOR).each((_index, element) => {
-			const bookElement = $(element);
-			const id = bookElement.attr(BOOK_ASIN_ATTR);
-			const title = bookElement.find(BOOK_TITLE_SELECTOR).text()?.trim();
-			const author =
-				bookElement
-					.find(BOOK_AUTHOR_SELECTOR)
-					.text()
-					?.trim()
-					.replace(/^By\s+/i, "") || // Remove "By " prefix
-				"Unknown Author"; // Provide default if author not found
-			const coverUrl = bookElement.find(BOOK_COVER_SELECTOR).attr("src");
-
-			if (id && title) {
-				books.push({
-					id,
-					title,
-					author,
-					// coverUrl, // Add if needed and selector is correct
-					// metadata: {}, // Initialize metadata if needed later
-				});
-			} else {
-				console.warn(
-					"Skipping book element due to missing ID or Title:",
-					bookElement.html()
+				// Clean up the iframe
+				document.body.removeChild(iframe);
+				console.log(
+					"Logout iframe navigation attempted and iframe removed."
 				);
+			} catch (error) {
+				console.error("Error during iframe logout attempt:", error);
+				// Ignore errors here, as it's a best-effort attempt
 			}
-		});
-		console.log(`Parsed ${books.length} books.`);
-
-		// --- Parse Highlights ---
-		// Assuming highlights for all books are present on the page
-		$(HIGHLIGHT_CONTAINER_SELECTOR).each((_index, element) => {
-			const highlightElement = $(element);
-			const bookId = highlightElement.attr(HIGHLIGHT_ASIN_ATTR); // Get associated book ASIN
-			const text = highlightElement
-				.find(HIGHLIGHT_TEXT_SELECTOR)
-				.text()
-				?.trim();
-			const note =
-				highlightElement.find(HIGHLIGHT_NOTE_SELECTOR).text()?.trim() ||
-				undefined; // Note is optional
-			const locationHeader = highlightElement
-				.find(HIGHLIGHT_LOCATION_SELECTOR)
-				.text()
-				?.trim();
-
-			// Basic parsing for location and page (might need refinement)
-			const location = locationHeader || "Unknown Location";
-			let page: number | undefined;
-			const pageMatch = location.match(/page (\d+)/i);
-			if (pageMatch) {
-				page = parseInt(pageMatch[1], 10);
-			}
-
-			// Generate a simple ID for the highlight (KCR might not provide stable ones)
-			const id = `highlight-${bookId}-${_index}`; // Simple index-based ID
-
-			if (bookId && text) {
-				highlights.push({
-					id,
-					bookId,
-					text,
-					location,
-					page,
-					note,
-					// createdAt: undefined, // Date parsing is complex from HTML, skip for now
-				});
-			} else {
-				console.warn(
-					"Skipping highlight element due to missing Book ID or Text:",
-					highlightElement.html()
-				);
-			}
-		});
-		console.log(`Parsed ${highlights.length} highlights.`);
-
-		if (books.length === 0 && highlights.length === 0) {
+		} else {
 			console.warn(
-				"No books or highlights found on the notebook page. Is the page structure correct or has it changed?"
-			);
-			// Show a notice if the page seems empty but login was successful
-			new Notice(
-				"Could not find any books or highlights on the Kindle Notebook page. The page structure might have changed, or there might be no highlights."
+				`Logout URL not found for region: ${region}. Skipping iframe logout attempt.`
 			);
 		}
 
-		return { books, highlights };
-	} catch (error) {
-		console.error("Error scraping Kindle highlights:", error);
-		new Notice(`Error scraping Kindle highlights: ${error.message}`);
-		// Re-throw or return empty to allow sync process to handle failure
-		throw error; // Or return { books: [], highlights: [] };
+		new Notice(
+			"Logged out from Kindle session (internal state cleared). Session clearing via Amazon is best-effort."
+		);
+	}
+
+	/**
+	 * Fetches books and highlights from the Kindle Cloud Reader notebook page.
+	 * Requires the user to be logged in.
+	 * @param region The Amazon region code.
+	 * @returns An object containing arrays of books and highlights.
+	 */
+	public async fetchHighlights(
+		region: string
+	): Promise<{ books: Book[]; highlights: Highlight[] }> {
+		if (!this.loggedIn) {
+			const errorMsg = "Not logged in to Amazon Kindle.";
+			console.error(`KindleApiService: ${errorMsg}`);
+			new Notice(errorMsg);
+			throw new Error(errorMsg);
+		}
+
+		console.log("KindleApiService: Fetching highlights...");
+		const regionUrls = getRegionUrls(region);
+		if (!regionUrls) {
+			const errorMsg = `Invalid or unsupported Amazon region: ${region}`;
+			console.error(`KindleApiService: ${errorMsg}`);
+			new Notice(errorMsg);
+			throw new Error(errorMsg);
+		}
+		const notebookUrl = regionUrls.notebookUrl;
+		console.log(
+			`KindleApiService: Scraping Kindle notebook: ${notebookUrl}`
+		);
+
+		try {
+			const response = await requestUrl({
+				url: notebookUrl,
+				method: "GET",
+				headers: {
+					"User-Agent": USER_AGENT,
+					Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+					"Accept-Language": "en-US,en;q=0.9",
+					// Cookies are expected to be handled implicitly by requestUrl/Electron session
+				},
+				throw: false,
+			});
+
+			console.log(
+				`KindleApiService: Scraping response status: ${response.status}`
+			);
+
+			// Check for potential redirect to login page (indicating invalid session)
+			if (response.status >= 300 && response.status < 400) {
+				const location = response.headers["location"];
+				if (location && location.includes("/ap/signin")) {
+					this.loggedIn = false; // Update state as session is invalid
+					throw new Error(
+						"Authentication failed or session expired. Please log in again."
+					);
+				}
+			}
+
+			if (response.status !== 200) {
+				// Could be a temporary error, don't necessarily invalidate login state yet
+				throw new Error(
+					`Failed to fetch Kindle Notebook page. Status: ${response.status}`
+				);
+			}
+
+			const html = response.text;
+			const $ = cheerio.load(html);
+
+			const books: Book[] = [];
+			const highlights: Highlight[] = [];
+
+			// --- Parse Books --- (Logic remains the same as before)
+			$(BOOK_SELECTOR).each((_index, element) => {
+				const bookElement = $(element);
+				const id = bookElement.attr(BOOK_ASIN_ATTR);
+				const title = bookElement
+					.find(BOOK_TITLE_SELECTOR)
+					.text()
+					?.trim();
+				const author =
+					bookElement
+						.find(BOOK_AUTHOR_SELECTOR)
+						.text()
+						?.trim()
+						.replace(/^By\s+/i, "") || "Unknown Author";
+				// const coverUrl = bookElement // Commented out to fix unused variable warning
+				// 	.find(BOOK_COVER_SELECTOR)
+				// 	.attr("src"); // Keep parsing, even if unused for now
+
+				if (id && title) {
+					books.push({ id, title, author /* coverUrl */ });
+				} else {
+					console.warn(
+						"Skipping book element due to missing ID or Title:",
+						bookElement.html()
+					);
+				}
+			});
+			console.log(`KindleApiService: Parsed ${books.length} books.`);
+
+			// --- Parse Highlights --- (Logic remains the same as before)
+			$(HIGHLIGHT_CONTAINER_SELECTOR).each((_index, element) => {
+				const highlightElement = $(element);
+				const bookId = highlightElement.attr(HIGHLIGHT_ASIN_ATTR);
+				const text = highlightElement
+					.find(HIGHLIGHT_TEXT_SELECTOR)
+					.text()
+					?.trim();
+				const note =
+					highlightElement
+						.find(HIGHLIGHT_NOTE_SELECTOR)
+						.text()
+						?.trim() || undefined;
+				const locationHeader = highlightElement
+					.find(HIGHLIGHT_LOCATION_SELECTOR)
+					.text()
+					?.trim();
+				const location = locationHeader || "Unknown Location";
+				let page: number | undefined;
+				const pageMatch = location.match(/page (\d+)/i);
+				if (pageMatch) {
+					page = parseInt(pageMatch[1], 10);
+				}
+				const id = `highlight-${bookId}-${_index}`;
+
+				if (bookId && text) {
+					highlights.push({ id, bookId, text, location, page, note });
+				} else {
+					console.warn(
+						"Skipping highlight element due to missing Book ID or Text:",
+						highlightElement.html()
+					);
+				}
+			});
+			console.log(
+				`KindleApiService: Parsed ${highlights.length} highlights.`
+			);
+
+			if (
+				books.length === 0 &&
+				highlights.length === 0 &&
+				response.text.length > 0
+			) {
+				// Check response text length to avoid false positives on empty responses
+				console.warn(
+					"No books or highlights found on the notebook page. Structure might have changed?"
+				);
+				new Notice(
+					"Could not find any books or highlights on the Kindle Notebook page. The page structure might have changed, or there might be no highlights."
+				);
+			}
+
+			return { books, highlights };
+		} catch (error) {
+			console.error(
+				"KindleApiService: Error fetching highlights:",
+				error
+			);
+			// Don't automatically log out on fetch errors, could be temporary
+			new Notice(`Error fetching Kindle highlights: ${error.message}`);
+			throw error;
+		}
 	}
 }
+
+// Remove the old exported scrapeKindleHighlights function if it exists at the end


### PR DESCRIPTION
Replaces the iframe-based login modal with Electron's BrowserWindow
to improve reliability and compatibility with Amazon's login flow,
particularly for regions like amazon.co.jp that had issues with
cookie handling and API access within the sandboxed iframe.

This resolves issues where the login page would get stuck asking for
cookies or fail due to restricted browser features. Login success is
now detected by monitoring navigation events in the separate window.