### PR TITLE
Add template preview functionality

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,6 +39,12 @@
 			"title": "Note Template",
 			"description": "Edit your template below (uses Nunjucks syntax). See Nunjucks documentation for details. Click on a variable to insert it into the template.",
 			"resetButton": "Reset to Default",
+			"preview": {
+				"title": "Preview",
+				"description": "Live preview of your template with sample data",
+				"errorTitle": "Template Error",
+				"errorDescription": "Please fix the template syntax to see the preview"
+			},
 			"variables": {
 				"title": "Available Variables",
 				"headerVariable": "Variable",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -39,6 +39,12 @@
 			"title": "ノートテンプレート",
 			"description": "以下でテンプレートを編集します（Nunjucks構文を使用）。詳細はNunjucksのドキュメントを参照してください。変数をクリックするとテンプレートに挿入されます。",
 			"resetButton": "デフォルトに戻す",
+			"preview": {
+				"title": "プレビュー",
+				"description": "サンプルデータを使用したテンプレートのライブプレビュー",
+				"errorTitle": "テンプレートエラー",
+				"errorDescription": "プレビューを表示するには、テンプレート構文を修正してください"
+			},
 			"variables": {
 				"title": "利用可能な変数",
 				"headerVariable": "変数",


### PR DESCRIPTION
Implements issue #13: テンプレート設定の下にプレビュー画面を設ける

Adds a real-time preview screen below template settings to help users understand how their template will be rendered in notes.

**Features:**
- Real-time preview with sample data
- Live updates on template changes
- Error handling for invalid syntax
- Responsive grid layout
- Bilingual UI support

Generated with [Claude Code](https://claude.ai/code)