### PR TITLE
Fix template preview issues: align headers and show Obsidian reading view

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,6 +39,10 @@
 			"title": "Note Template",
 			"description": "Edit your template below (uses Nunjucks syntax). See Nunjucks documentation for details. Click on a variable to insert it into the template.",
 			"resetButton": "Reset to Default",
+			"preview": {
+				"title": "Preview",
+				"error": "Template Error: {{error}}"
+			},
 			"variables": {
 				"title": "Available Variables",
 				"headerVariable": "Variable",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -39,6 +39,10 @@
 			"title": "ノートテンプレート",
 			"description": "以下でテンプレートを編集します（Nunjucks構文を使用）。詳細はNunjucksのドキュメントを参照してください。変数をクリックするとテンプレートに挿入されます。",
 			"resetButton": "デフォルトに戻す",
+			"preview": {
+				"title": "プレビュー",
+				"error": "テンプレートエラー: {{error}}"
+			},
 			"variables": {
 				"title": "利用可能な変数",
 				"headerVariable": "変数",


### PR DESCRIPTION
Fixes issue #13: テンプレート設定の下にプレビュー画面を設ける

Resolved two key problems with template preview functionality:

**1. Header Alignment Issue**
- Fixed misalignment between template editor and preview windows
- "ノートテンプレート" and "プレビュー" headers now aligned at same height

**2. Obsidian Reading View Format**
- Changed preview from displaying raw template to proper Obsidian reading view
- Renders markdown with proper formatting, headers, blockquotes, and links

**Features:**
- Side-by-side grid layout for editor and preview
- Live preview updates on template changes
- Sample Japanese book data for realistic preview
- Error handling for invalid template syntax
- Bilingual UI support (English/Japanese)

Generated with [Claude Code](https://claude.ai/code)