### PR TITLE
fix: use translation function for Amazon Region setting title

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -484,7 +484,7 @@ export class KindleHighlightsSettingTab extends PluginSettingTab {
 		document.head.appendChild(styleEl);
 
 		new Setting(containerEl)
-			.setName("Amazon Region")
+			.setName(t("settings.amazonRegion.name"))
 			.setDesc(t("settings.amazonRegion.description"))
 			.addDropdown((dropdown) => {
 				for (const key of AMAZON_REGION_KEYS) {


### PR DESCRIPTION
Fixed hardcoded "Amazon Region" string in settings dropdown to use proper localization. Now displays correctly in both English and Japanese languages.

Fixes #19