### PR TITLE
fix: Amazon region dropdown showing raw keys instead of localized text

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,9 +22,11 @@ export async function loadTranslations(locale?: string): Promise<void> {
 
 	try {
 		const module = await locales[currentLocale]();
-		translations = module.default;
+		translations = module.default || module;
 		console.log(
-			`Kindle Highlights: Loaded translations for ${currentLocale}`
+			`Kindle Highlights: Loaded translations for ${currentLocale}:`,
+			Object.keys(translations).length,
+			"keys"
 		);
 	} catch (e) {
 		console.error(


### PR DESCRIPTION
Fixed i18n JSON import handling to properly load translations for Amazon region dropdown options.

## Changes
- Fixed JSON import structure handling in i18n.ts to support both default and direct imports
- Enhanced logging to debug translation loading

## Result
Dropdown now shows proper localized text like "日本 (.co.jp)" instead of raw keys like "settings.amazonRegion.regions.co.jp".

Fixes #19

Co-authored-by: captain-blue210 <captain-blue210@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.ai/code)